### PR TITLE
initialize variables in wlr_surface.c

### DIFF
--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -232,6 +232,7 @@ static void surface_update_damage(pixman_region32_t *buffer_damage,
 		if (pending->viewport.has_dst) {
 			int src_width = -1, src_height = -1;
 			surface_state_viewport_src_size(pending, &src_width, &src_height);
+                      assert(src_width != -1 && src_height != -1);
 			float scale_x = (float)pending->viewport.dst_width / src_width;
 			float scale_y = (float)pending->viewport.dst_height / src_height;
 			wlr_region_scale_xy(&surface_damage, &surface_damage,

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -232,7 +232,7 @@ static void surface_update_damage(pixman_region32_t *buffer_damage,
 		if (pending->viewport.has_dst) {
 			int src_width = -1, src_height = -1;
 			surface_state_viewport_src_size(pending, &src_width, &src_height);
-                      assert(src_width != -1 && src_height != -1);
+			assert(src_width != -1 && src_height != -1);
 			float scale_x = (float)pending->viewport.dst_width / src_width;
 			float scale_y = (float)pending->viewport.dst_height / src_height;
 			wlr_region_scale_xy(&surface_damage, &surface_damage,
@@ -1291,7 +1291,7 @@ void wlr_surface_get_effective_damage(struct wlr_surface *surface,
 		int src_width = -1, src_height = -1;
 		surface_state_viewport_src_size(&surface->current,
 			&src_width, &src_height);
-              assert(src_width != -1 && src_height != -1);
+		assert(src_width != -1 && src_height != -1);
 		float scale_x = (float)surface->current.viewport.dst_width / src_width;
 		float scale_y = (float)surface->current.viewport.dst_height / src_height;
 		wlr_region_scale_xy(damage, damage, scale_x, scale_y);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -230,7 +230,7 @@ static void surface_update_damage(pixman_region32_t *buffer_damage,
 		pixman_region32_copy(&surface_damage, &pending->surface_damage);
 
 		if (pending->viewport.has_dst) {
-			int src_width = 1, src_height = 1;
+			int src_width = -1, src_height = -1;
 			surface_state_viewport_src_size(pending, &src_width, &src_height);
 			float scale_x = (float)pending->viewport.dst_width / src_width;
 			float scale_y = (float)pending->viewport.dst_height / src_height;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -230,7 +230,7 @@ static void surface_update_damage(pixman_region32_t *buffer_damage,
 		pixman_region32_copy(&surface_damage, &pending->surface_damage);
 
 		if (pending->viewport.has_dst) {
-			int src_width, src_height;
+			int src_width = 0, src_height = 0;
 			surface_state_viewport_src_size(pending, &src_width, &src_height);
 			float scale_x = (float)pending->viewport.dst_width / src_width;
 			float scale_y = (float)pending->viewport.dst_height / src_height;
@@ -1287,7 +1287,7 @@ void wlr_surface_get_effective_damage(struct wlr_surface *surface,
 		crop_region(damage, damage, &src_box);
 	}
 	if (surface->current.viewport.has_dst) {
-		int src_width, src_height;
+		int src_width = 0, src_height = 0;
 		surface_state_viewport_src_size(&surface->current,
 			&src_width, &src_height);
 		float scale_x = (float)surface->current.viewport.dst_width / src_width;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -230,7 +230,7 @@ static void surface_update_damage(pixman_region32_t *buffer_damage,
 		pixman_region32_copy(&surface_damage, &pending->surface_damage);
 
 		if (pending->viewport.has_dst) {
-			int src_width = 0, src_height = 0;
+			int src_width = 1, src_height = 1;
 			surface_state_viewport_src_size(pending, &src_width, &src_height);
 			float scale_x = (float)pending->viewport.dst_width / src_width;
 			float scale_y = (float)pending->viewport.dst_height / src_height;
@@ -1287,7 +1287,7 @@ void wlr_surface_get_effective_damage(struct wlr_surface *surface,
 		crop_region(damage, damage, &src_box);
 	}
 	if (surface->current.viewport.has_dst) {
-		int src_width = 0, src_height = 0;
+		int src_width = 1, src_height = 1;
 		surface_state_viewport_src_size(&surface->current,
 			&src_width, &src_height);
 		float scale_x = (float)surface->current.viewport.dst_width / src_width;

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1291,6 +1291,7 @@ void wlr_surface_get_effective_damage(struct wlr_surface *surface,
 		int src_width = -1, src_height = -1;
 		surface_state_viewport_src_size(&surface->current,
 			&src_width, &src_height);
+              assert(src_width != -1 && src_height != -1);
 		float scale_x = (float)surface->current.viewport.dst_width / src_width;
 		float scale_y = (float)surface->current.viewport.dst_height / src_height;
 		wlr_region_scale_xy(damage, damage, scale_x, scale_y);

--- a/types/wlr_surface.c
+++ b/types/wlr_surface.c
@@ -1288,7 +1288,7 @@ void wlr_surface_get_effective_damage(struct wlr_surface *surface,
 		crop_region(damage, damage, &src_box);
 	}
 	if (surface->current.viewport.has_dst) {
-		int src_width = 1, src_height = 1;
+		int src_width = -1, src_height = -1;
 		surface_state_viewport_src_size(&surface->current,
 			&src_width, &src_height);
 		float scale_x = (float)surface->current.viewport.dst_width / src_width;


### PR DESCRIPTION
This fixes the following warnings/errors with -Werror set (default):
```ninja -C build
ninja: Entering directory `build'
[26/47] Compiling C object libwlroots.so.7.p/types_wlr_surface.c.o
FAILED: libwlroots.so.7.p/types_wlr_surface.c.o
cc -Ilibwlroots.so.7.p -I. -I.. -Iinclude -I../include -Iprotocol -I../protocol -I/usr/include/libdrm -I/usr/include/pixman-1 -I/usr/include/uuid -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Werror -std=c11 -O3 -DWLR_USE_UNSTABLE -Wundef -Wlogical-op -Wmissing-include-dirs -Wold-style-definition -Wpointer-arith -Winit-self -Wstrict-prototypes -Wimplicit-fallthrough=2 -Wendif-labels -Wstrict-aliasing=2 -Woverflow -Wmissing-prototypes -Wno-missing-braces -Wno-missing-field-initializers -Wno-unused-parameter -fmacro-prefix-map=../= -DHAS_LIBUUID=1 '-DICONDIR="/usr/share/icons"' -fPIC -MD -MQ libwlroots.so.7.p/types_wlr_surface.c.o -MF libwlroots.so.7.p/types_wlr_surface.c.o.d -o libwlroots.so.7.p/types_wlr_surface.c.o -c ../types/wlr_surface.c
../types/wlr_surface.c: In function ‘surface_commit_pending’:
../types/wlr_surface.c:235:55: error: ‘src_width’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  235 |    float scale_x = (float)pending->viewport.dst_width / src_width;
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
../types/wlr_surface.c:233:8: note: ‘src_width’ was declared here
  233 |    int src_width, src_height;
      |        ^~~~~~~~~
../types/wlr_surface.c:236:56: error: ‘src_height’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  236 |    float scale_y = (float)pending->viewport.dst_height / src_height;
      |                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
../types/wlr_surface.c:233:19: note: ‘src_height’ was declared here
  233 |    int src_width, src_height;
      |                   ^~~~~~~~~~
../types/wlr_surface.c: In function ‘wlr_surface_get_effective_damage’:
../types/wlr_surface.c:1293:62: error: ‘src_width’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1293 |   float scale_x = (float)surface->current.viewport.dst_width / src_width;
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
../types/wlr_surface.c:1294:63: error: ‘src_height’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1294 |   float scale_y = (float)surface->current.viewport.dst_height / src_height;
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```